### PR TITLE
Implement InputEncoder and VQCLayer for classical-to-quantum data embedding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,16 +1,16 @@
 import pennylane as qml
 import numpy as np
 
-class InputEncoder:
-    def __init__(self,classic_input:np.ndarray,device_type:str='default.qubit'):
 
+class InputEncoder:
+    def __init__(self, classic_input: np.ndarray, device_type: str = 'default.qubit'):
         """
         Initialize encoder with classical input.
         Args:
             classic_input: Input array
-            device_type: Pennylane device type
+            device_type: PennyLane device type
         """
-        self.classic_input = np.asarray(classic_input,dtype=np.float64)
+        self.classic_input = np.asarray(classic_input, dtype=np.float64)
         self.n_qubits = len(self.classic_input)
         self.device_type = device_type
         self.device = None
@@ -21,70 +21,137 @@ class InputEncoder:
         Pad input to the next power of 2 and update n_qubits if needed
         """
         length = len(self.classic_input)
-        next_power_of_2 = 2 ** np.ceil(np.log2(max(length,1))).astype(int)
-        if next_power_of_2> self.n_qubits:
-            self.n_qubits=next_power_of_2
+        next_power_of_2 = 2 ** np.ceil(np.log2(max(length, 1))).astype(int)
+        if next_power_of_2 > self.n_qubits:
+            self.n_qubits = next_power_of_2
 
-        self.classic_input=np.pad(self.classic_input , (0,self.n_qubits-length ),'constant')
+        self.classic_input = np.pad(
+            self.classic_input,
+            (0, self.n_qubits - length),
+            'constant'
+        )
 
-    def prepare_state(self):
+    def prepare_state(self, embedding_type: str):
         """
-        Apply hadamrad gates to all qubits for superpositon
+        Apply Hadamard gates to all qubits for superposition
+        Only used for angle embedding.
         """
-        for i in range(self.n_qubits):
-            qml.Hadamard(wires=i)
+        if embedding_type == "angle":
+            for i in range(self.n_qubits):
+                qml.Hadamard(wires=i)
 
-    def encode_input(self, gate_type:str = 'Y', embedding_type:str = 'angle', operation_type:str = 'initialization', with_padding:bool = False , device:qml.device = None):
+    def encode_input(
+        self,
+        gate_type: str = 'Y',
+        embedding_type: str = 'angle',
+        operation_type: str = 'initialization',
+        with_padding: bool = False,
+        device: qml.device = None,
+        interface: str = 'autograd',
+        operations_list=None,
+        return_state: bool = True
+    ):
         """
-        Encode input into quantum state
+        Encode input into quantum state and optionally apply operations.
 
         Args:
-            gate_type: Rotation gate for angle embedding 
-            embedding_type: angle or amplitude
-            operation_type: initialization (hadamard + embedding)
-            with_padding:pad to power of 2
+            gate_type: Rotation gate for angle embedding ('X','Y','Z')
+            embedding_type: 'angle' or 'amplitude'
+            operation_type: 'initialization' or 'operations'
+            with_padding: pad to power of 2
             device: optional pre-existing device to reuse
+            interface: ML interface for QNode ('autograd','torch','jax','tf')
+            operations_list: list of quantum ops to apply after embedding
+            return_state: if True returns statevector, else expval <Z0>
 
-        Returns: 
-            qml.QNode: qunatum circuit for encoding
+        Returns:
+            qml.QNode: quantum circuit for encoding
         """
-        if with_padding or embedding_type == 'amplitude':
+        # Validate rotation gate
+        valid_rotations = ['X', 'Y', 'Z']
+        if embedding_type == "angle" and gate_type not in valid_rotations:
+            raise ValueError(f"gate_type must be one of {valid_rotations}")
+
+        # Handle padding
+        if embedding_type == "amplitude" or with_padding:
             self.add_padding()
-
         else:
-            self.n_qubits=len(self.classic_input)
+            self.n_qubits = len(self.classic_input)
 
-        self.device=device if device is not None else qml.device(self.device_type, wires = self.n_qubits)
+        # Device initialization
+        self.device = device if device is not None else qml.device(
+            self.device_type, wires=self.n_qubits
+        )
 
-        @qml.qnode(self.device, interface = 'torch', diff_method = 'parameter-shift')
+        @qml.qnode(self.device, interface=interface, diff_method='parameter-shift')
         def circuit():
+            # Initialization embedding
             if operation_type == "initialization":
                 if embedding_type == "angle":
-                    self.prepare_state()
-                    qml.AngleEmbedding(self.classic_input, wires=range(self.n_qubits), rotation=gate_type)
-
+                    self.prepare_state(embedding_type)
+                    qml.AngleEmbedding(
+                        self.classic_input,
+                        wires=range(self.n_qubits),
+                        rotation=gate_type
+                    )
                 elif embedding_type == "amplitude":
-                    qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+                    qml.AmplitudeEmbedding(
+                        self.classic_input,
+                        wires=range(self.n_qubits),
+                        normalize=True,
+                        pad_with=0.0
+                    )
 
+            # Apply additional operations on top of embedding
+            if operations_list:
+                for op in operations_list:
+                    qml.apply(op)
+
+            # Measurement
+            if return_state:
+                return qml.state()
             else:
-                qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+                return qml.expval(qml.PauliZ(0))
 
-            return  qml.state()
         return circuit
-    
+
+
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
-    # Test input
+
+    # Input and device
     input_data = np.asarray([0, 0, 1])
     encoder = InputEncoder(input_data)
-    circuit = encoder.encode_input(with_padding=False)
-    state = circuit()
-    print("Input:", input_data)
-    print("n_qubits:", encoder.n_qubits)
-    print("State:", state)
-    fig, ax = qml.draw_mpl(circuit)()
+    dev = qml.device("default.qubit", wires=3)
+
+    # Case 1: Initialization (angle embedding)
+    # circuit1 = encoder.encode_input(
+    #     device=dev,
+    #     embedding_type="angle",
+    #     gate_type="Y",
+    #     with_padding=False,
+    #     return_state=True
+    # )
+    # state = circuit1()
+    # print("Initialization State:", state)
+
+    # Case 2: Initialization + operations
+    ops = [
+        qml.Hadamard(wires=0),
+        qml.CNOT(wires=[0, 1]),
+        qml.CNOT(wires=[1, 2])
+    ]
+    circuit2 = encoder.encode_input(
+        device=dev,
+        embedding_type="angle",
+        gate_type="Y",
+        with_padding=False,
+        operations_list=ops,
+        return_state=False
+    )
+    result = circuit2()
+    print("Expectation value <Z0>:", result)
+
+    # Draw circuit
+    fig, ax = qml.draw_mpl(circuit2)()
     plt.show()
-
-
-        
-

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,61 +1,90 @@
 import pennylane as qml
 import numpy as np
 
-np.random.seed(11111)
 class InputEncoder:
-    def __init__(self, classic_input: np.ndarray , n_qubits: int, device_type = 'default.qubit'):
-        self.classic_input = classic_input
-        self.n_qubits = n_qubits
-        self.device = qml.device(device_type, wires=n_qubits)
+    def __init__(self,classic_input:np.ndarray,device_type:str='default.qubit'):
+
+        """
+        Initialize encoder with classical input.
+        Args:
+            classic_input: Input array
+            device_type: Pennylane device type
+        """
+        self.classic_input = np.asarray(classic_input,dtype=np.float64)
+        self.n_qubits = len(self.classic_input)
+        self.device_type = device_type
+        self.device = None
         self.random_generator = np.random.default_rng()
+
     def add_padding(self):
-        """"
-        Add padding to the input data to match the number of qubits. 
-        This is done by adding zeros to the end of the input data to make the length
-        the power of 2.
+        """
+        Pad input to the next power of 2 and update n_qubits if needed
         """
         length = len(self.classic_input)
-        next_power_of_2 = 2 ** np.ceil(np.log2(length)).astype(int)
-        padding_length = next_power_of_2 - length
-        self.classic_input = np.pad(self.classic_input, (0, padding_length), 'constant')
+        next_power_of_2 = 2 ** np.ceil(np.log2(max(length,1))).astype(int)
+        if next_power_of_2> self.n_qubits:
+            self.n_qubits=next_power_of_2
 
+        self.classic_input=np.pad(self.classic_input , (0,self.n_qubits-length ),'constant')
 
     def prepare_state(self):
         """
-        Used to prepare the quantum state from classical input data.
-        1. Add padding to the input data to match the number of qubits.
-        2. Apply Hadamard gate to each qubit to create superposition state.
-        3. Return the prepared quantum state.
+        Apply hadamrad gates to all qubits for superpositon
         """
-        # Apply Hadamard gate to each qubit to create superposition state
-        for i in range(len(self.classic_input)):
+        for i in range(self.n_qubits):
             qml.Hadamard(wires=i)
 
+    def encode_input(self, gate_type:str = 'Y', embedding_type:str = 'angle', operation_type:str = 'initialization', with_padding:bool = False , device:qml.device = None):
+        """
+        Encode input into quantum state
 
-    def encode_input(self, device, gate_type='Y', embedding_type = 'angle', operation_type = "initialization", with_padding=True):
-        @qml.qnode(device)
+        Args:
+            gate_type: Rotation gate for angle embedding 
+            embedding_type: angle or amplitude
+            operation_type: initialization (hadamard + embedding)
+            with_padding:pad to power of 2
+            device: optional pre-existing device to reuse
+
+        Returns: 
+            qml.QNode: qunatum circuit for encoding
+        """
+        if with_padding or embedding_type == 'amplitude':
+            self.add_padding()
+
+        else:
+            self.n_qubits=len(self.classic_input)
+
+        self.device=device if device is not None else qml.device(self.device_type, wires = self.n_qubits)
+
+        @qml.qnode(self.device, interface = 'torch', diff_method = 'parameter-shift')
         def circuit():
-            if operation_type == "initialization":  
-                if with_padding:
-                    self.add_padding()
-                if embedding_type == 'angle':
+            if operation_type == "initialization":
+                if embedding_type == "angle":
                     self.prepare_state()
-                    #creating an angle embedding for the input data
-                    qml.AngleEmbedding(self.classic_input, wires=range(len(self.classic_input)), rotation=gate_type)
-                elif embedding_type == 'amplitude':
-                    #creating an amplitude embedding for the input data
-                    qml.AmplitudeEmbedding(self.classic_input, wires=range(len(self.classic_input)), normalize=True, pad_with=0.0)
+                    qml.AngleEmbedding(self.classic_input, wires=range(self.n_qubits), rotation=gate_type)
+
+                elif embedding_type == "amplitude":
+                    qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+
             else:
-                qml.AmplitudeEmbedding(self.classic_input, wires=range(len(self.classic_input)), normalize=True, pad_with=0.0)
-            return qml.expval(qml.PauliZ(0))
+                qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+
+            return  qml.state()
         return circuit
     
-    
-# if __name__=="__main__":
-#     inst = InputEncoder(np.asarray([0, 0, 1]), 3)
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    # Test input
+    input_data = np.asarray([0, 0, 1])
+    encoder = InputEncoder(input_data)
+    circuit = encoder.encode_input(with_padding=False)
+    state = circuit()
+    print("Input:", input_data)
+    print("n_qubits:", encoder.n_qubits)
+    print("State:", state)
+    fig, ax = qml.draw_mpl(circuit)()
+    plt.show()
 
-#     dev = qml.device('default.qubit', wires=3)
-#     circuit = inst.encode_input(dev)
-#     drawer = qml.draw_mpl(circuit)()
 
-  
+        
+

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,5 +1,6 @@
 import pennylane as qml
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 class InputEncoder:
@@ -117,7 +118,7 @@ class InputEncoder:
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
+   
 
     # Input and device
     input_data = np.asarray([0, 0, 1])
@@ -125,33 +126,33 @@ if __name__ == "__main__":
     dev = qml.device("default.qubit", wires=3)
 
     # Case 1: Initialization (angle embedding)
-    # circuit1 = encoder.encode_input(
-    #     device=dev,
-    #     embedding_type="angle",
-    #     gate_type="Y",
-    #     with_padding=False,
-    #     return_state=True
-    # )
-    # state = circuit1()
-    # print("Initialization State:", state)
-
-    # Case 2: Initialization + operations
-    ops = [
-        qml.Hadamard(wires=0),
-        qml.CNOT(wires=[0, 1]),
-        qml.CNOT(wires=[1, 2])
-    ]
-    circuit2 = encoder.encode_input(
+    circuit1 = encoder.encode_input(
         device=dev,
         embedding_type="angle",
         gate_type="Y",
         with_padding=False,
-        operations_list=ops,
-        return_state=False
+        return_state=True
     )
-    result = circuit2()
-    print("Expectation value <Z0>:", result)
+    state = circuit1()
+    print("Initialization State:", state)
+
+    # Case 2: Initialization + operations
+    # ops = [
+    #     qml.Hadamard(wires=0),
+    #     qml.CNOT(wires=[0, 1]),
+    #     qml.CNOT(wires=[1, 2])
+    # ]
+    # circuit2 = encoder.encode_input(
+    #     device=dev,
+    #     embedding_type="angle",
+    #     gate_type="Y",
+    #     with_padding=False,
+    #     operations_list=ops,
+    #     return_state=False
+    # )
+    # result = circuit2()
+    # print("Expectation value <Z0>:", result)
 
     # Draw circuit
-    fig, ax = qml.draw_mpl(circuit2)()
+    # fig, ax = qml.draw_mpl(circuit2)()
     plt.show()

--- a/src/vqc_fnn/models/vqc_layer.py
+++ b/src/vqc_fnn/models/vqc_layer.py
@@ -1,12 +1,98 @@
 from torch import nn
+import torch
 import pennylane as qml
-from qiskit import QuantumCircuit
 from input_encoder import InputEncoder
+from qiskit import QuantumCircuit
+import numpy as np
+
 class VQCLayer(nn.Module):
-    def __init__(self, num_qubits, q_circuit: QuantumCircuit | qml.QuantumCircuit):
+    def __init__(self, num_qubits, q_circuit: QuantumCircuit | None = None, n_layers: int = 1, encoder: InputEncoder | None = None):
+        """
+        Variational Quantum Circuit (VQC) Layer.
+
+        Args:
+            num_qubits (int): Number of qubits in the VQC.
+            q_circuit (QuantumCircuit | None): Optional custom Qiskit or Pennylane circuit.
+            n_layers (int): Number of entangler layers if using default Pennylane VQC.
+            encoder (InputEncoder | None): Optional InputEncoder for classical-to-quantum encoding.
+        """
         super(VQCLayer, self).__init__()
-        
+        self.num_qubits = num_qubits
+        self.encoder = encoder
+        self.n_layers = n_layers
+
+        # Initialize Pennylane device
+        self.dev = qml.device("default.qubit", wires=self.num_qubits)
+
+        # Trainable parameters for the entangler layers
+        self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=self.n_layers, n_wires=self.num_qubits)
+        self.weights = nn.Parameter(torch.randn(*self.weight_shape) * np.pi)
+
+        # Define QNode using the provided circuit or default
+        self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
+
+    def _circuit(self, weights, inputs=None):
+        """
+        Quantum circuit for the VQC layer.
+
+        Args:
+            weights: Trainable parameters for entangler layers.
+            inputs: Classical input tensor for encoding.
+        """
+        # Encode classical input if encoder provided
+        if self.encoder is not None and inputs is not None:
+            # Convert torch.Tensor to numpy
+            self.encoder.classic_input = inputs.detach().cpu().numpy()
+            # Generate the circuit
+            self.encoder.encode_input(
+                gate_type='Y',
+                embedding_type='angle',
+                operation_type='initialization',
+                with_padding=False,
+                device=self.dev,
+                interface="torch",
+                operations_list=None,
+                return_state=False
+            )()
+
+        # Apply variational entangler layers
+        qml.BasicEntanglerLayers(weights, wires=range(self.num_qubits))
+
+        # Measure all qubits
+        return [qml.expval(qml.PauliZ(i)) for i in range(self.num_qubits)]
+
     def forward(self, input_):
-       pass
+        """
+        Forward pass through the VQC layer.
+
+        Args:
+            input_ (torch.Tensor): Input tensor of shape (batch_size, num_qubits) or (num_qubits,)
+
+        Returns:
+            torch.Tensor: Output tensor of shape (batch_size, num_qubits)
+        """
+        if isinstance(input_, torch.Tensor):
+            input_ = input_.float()
+
+        # Single input
+        if len(input_.shape) == 1:
+            return self.qnode(self.weights, inputs=input_)
+        # Batch input
+        else:
+            batch_out = [self.qnode(self.weights, inputs=x_i) for x_i in input_]
+            return torch.stack(batch_out)
+
     def backward(self, grad_output):
-       pass
+        """
+        Optional: define backward pass if using custom gradients.
+        For standard PyTorch + Pennylane, autograd handles gradients automatically.
+        """
+        pass
+
+if __name__ == '__main__':
+    x = torch.tensor([0.1, 0.5, 0.9])
+    encoder = InputEncoder(classic_input=x.numpy())
+    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
+
+    output = vqc(x)
+    print("VQC output:", output)

--- a/src/vqc_fnn/models/vqc_layer.py
+++ b/src/vqc_fnn/models/vqc_layer.py
@@ -1,87 +1,80 @@
-from torch import nn
 import torch
+from torch import nn
 import pennylane as qml
+import numpy as np
 from input_encoder import InputEncoder
 from qiskit import QuantumCircuit
-import numpy as np
 
 class VQCLayer(nn.Module):
-    def __init__(self, num_qubits, q_circuit: QuantumCircuit | None = None, n_layers: int = 1, encoder: InputEncoder | None = None):
+    def __init__(
+        self, 
+        num_qubits: int,
+        encoder: InputEncoder | None = None,
+        ansatz_fn=None,
+        n_layers: int = 1, 
+        device_type: str = "default.qubit",
+        measurement_fn=None,
+        q_circuit: QuantumCircuit | None = None, 
+    ):
         """
         Variational Quantum Circuit (VQC) Layer.
-
-        Args:
-            num_qubits (int): Number of qubits in the VQC.
-            q_circuit (QuantumCircuit | None): Optional custom Qiskit or Pennylane circuit.
-            n_layers (int): Number of entangler layers if using default Pennylane VQC.
-            encoder (InputEncoder | None): Optional InputEncoder for classical-to-quantum encoding.
         """
-        super(VQCLayer, self).__init__()
+        super().__init__()
         self.num_qubits = num_qubits
         self.encoder = encoder
         self.n_layers = n_layers
+        self.q_circuit = q_circuit
 
         # Initialize Pennylane device
-        self.dev = qml.device("default.qubit", wires=self.num_qubits)
+        self.dev = qml.device(device_type, wires=self.num_qubits)
 
-        # Trainable parameters for the entangler layers
-        self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=self.n_layers, n_wires=self.num_qubits)
+        # Default ansatz if not provided
+        if ansatz_fn is None:
+            self.ansatz_fn = lambda weights: qml.BasicEntanglerLayers(weights, wires=range(num_qubits))
+            self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=n_layers, n_wires=num_qubits)
+        else:
+            self.ansatz_fn = ansatz_fn
+            self.weight_shape = getattr(ansatz_fn, "weight_shape", (n_layers, num_qubits))
+
+        # Trainable weights
         self.weights = nn.Parameter(torch.randn(*self.weight_shape) * np.pi)
 
-        # Define QNode using the provided circuit or default
-        self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
+        # Default measurement: Z expectation on all qubits
+        if measurement_fn is None:
+            self.measurement_fn = lambda: [qml.expval(qml.PauliZ(i)) for i in range(num_qubits)]
+        else:
+            self.measurement_fn = measurement_fn
+
+        # Define QNode (custom circuit if provided)
+        if self.q_circuit is not None:
+            self.qnode = qml.QNode(self.q_circuit, self.dev, interface="torch")
+        else:
+            self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
 
     def _circuit(self, weights, inputs=None):
-        """
-        Quantum circuit for the VQC layer.
-
-        Args:
-            weights: Trainable parameters for entangler layers.
-            inputs: Classical input tensor for encoding.
-        """
+        """Quantum circuit for the VQC layer."""
         # Encode classical input if encoder provided
         if self.encoder is not None and inputs is not None:
-            # Convert torch.Tensor to numpy
             self.encoder.classic_input = inputs.detach().cpu().numpy()
-            # Generate the circuit
-            self.encoder.encode_input(
-                gate_type='Y',
-                embedding_type='angle',
-                operation_type='initialization',
-                with_padding=False,
-                device=self.dev,
-                interface="torch",
-                operations_list=None,
-                return_state=False
-            )()
+            embedding_fn = self.encoder.embedding_function(embedding_type="angle", gate_type="Y")
+            embedding_fn()
 
-        # Apply variational entangler layers
-        qml.BasicEntanglerLayers(weights, wires=range(self.num_qubits))
+        # Variational ansatz
+        self.ansatz_fn(weights)
 
-        # Measure all qubits
-        return [qml.expval(qml.PauliZ(i)) for i in range(self.num_qubits)]
+        # Measurement
+        return self.measurement_fn()
 
     def forward(self, input_):
-        """
-        Forward pass through the VQC layer.
+        """Forward pass with batch support."""
+        input_ = input_.float() if isinstance(input_, torch.Tensor) else input_
 
-        Args:
-            input_ (torch.Tensor): Input tensor of shape (batch_size, num_qubits) or (num_qubits,)
-
-        Returns:
-            torch.Tensor: Output tensor of shape (batch_size, num_qubits)
-        """
-        if isinstance(input_, torch.Tensor):
-            input_ = input_.float()
-
-        # Single input
-        if len(input_.shape) == 1:
+        if len(input_.shape) == 1:  # single input
             return self.qnode(self.weights, inputs=input_)
-        # Batch input
-        else:
+        else:  # batch
             batch_out = [self.qnode(self.weights, inputs=x_i) for x_i in input_]
             return torch.stack(batch_out)
-
+        
     def backward(self, grad_output):
         """
         Optional: define backward pass if using custom gradients.
@@ -89,10 +82,22 @@ class VQCLayer(nn.Module):
         """
         pass
 
+
 if __name__ == '__main__':
     x = torch.tensor([0.1, 0.5, 0.9])
     encoder = InputEncoder(classic_input=x.numpy())
-    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
 
-    output = vqc(x)
-    print("VQC output:", output)
+    # Default VQC
+    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
+    print("Default VQC output:", vqc(x))
+
+    # Custom ansatz
+    ansatz = lambda weights: qml.StronglyEntanglingLayers(weights, wires=range(3))
+    ansatz.weight_shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
+    vqc_custom = VQCLayer(num_qubits=3, encoder=encoder, ansatz_fn=ansatz)
+    print("Custom ansatz output:", vqc_custom(x))
+
+    # Custom measurement
+    measure_qubit0 = lambda: qml.expval(qml.PauliZ(0))
+    vqc_measure = VQCLayer(num_qubits=3, encoder=encoder, measurement_fn=measure_qubit0)
+    print("Custom measurement output:", vqc_measure(x))


### PR DESCRIPTION


1. **InputEncoder**: Encodes classical inputs into quantum states using angle or amplitude embeddings. Supports optional padding and additional operations if `operation_type` is not "initialization". Returns a Pennylane QNode representing the encoding circuit.

2. **VQCLayer**: A PyTorch module that runs a variational quantum circuit with trainable entangler layers. Integrates an InputEncoder to embed classical inputs and outputs expectation values for all qubits. Supports both single and batch inputs, with gradients handled automatically via Pennylane and PyTorch.
