### PR TITLE
Refactor InputEncoder to Stateless Design, Update VQCLayer, and Add Iris Dataset Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 *.pyo
 .DS_Store
+venv/

--- a/src/vqc_fnn/models/hybrid_qnn_iris.py
+++ b/src/vqc_fnn/models/hybrid_qnn_iris.py
@@ -1,0 +1,153 @@
+import torch
+from torch import nn, optim
+from torch.utils.data import TensorDataset, DataLoader, random_split
+import numpy as np
+import matplotlib.pyplot as plt
+import time
+
+from input_encoder import InputEncoder
+from vqc_layer import VQCLayer
+
+from sklearn.datasets import load_iris
+from sklearn.preprocessing import StandardScaler
+
+class HybridQNN(nn.Module):
+    def __init__(self, num_features, num_classes, n_vqc_layers=2, embedding_type="angle", gate_type="Y"):
+        super().__init__()
+        self.embedding_type = embedding_type
+        self.gate_type = gate_type
+
+        if embedding_type == "amplitude":
+            q_output_size = int(np.log2(VQCLayer._next_power_of_two_int(num_features)))
+        else:
+            q_output_size = num_features
+
+        self.quantum_layer = VQCLayer(
+            encoder=InputEncoder(),
+            n_layers=n_vqc_layers
+        )
+        self.linear_head = nn.Linear(q_output_size, num_classes)
+
+    def forward(self, x):
+        q_out = self.quantum_layer(x, embedding_type=self.embedding_type, gate_type=self.gate_type)
+        logits = self.linear_head(q_out)
+        return logits
+
+
+def get_iris_loaders(batch_size=16, val_ratio=0.2):
+    iris = load_iris()
+    X = iris.data
+    y = iris.target
+
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    X_tensor = torch.tensor(X_scaled, dtype=torch.float32)
+    y_tensor = torch.tensor(y, dtype=torch.long)
+
+    dataset = TensorDataset(X_tensor, y_tensor)
+    val_size = int(len(dataset) * val_ratio)
+    test_size = int(len(dataset) * 0.2)
+    train_size = len(dataset) - val_size - test_size
+
+    train_ds, val_ds, test_ds = random_split(dataset, [train_size, val_size, test_size])
+
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
+    test_loader = DataLoader(test_ds, batch_size=batch_size)
+
+    return train_loader, val_loader, test_loader
+
+def evaluate_model(model, loader, device):
+    model.eval()
+    correct = 0
+    total = 0
+    total_loss = 0
+    criterion = nn.CrossEntropyLoss()
+    with torch.no_grad():
+        for X, y in loader:
+            X, y = X.to(device), y.to(device)
+            outputs = model(X)
+            loss = criterion(outputs, y)
+            total_loss += loss.item() * y.size(0)
+            preds = outputs.argmax(dim=1)
+            correct += (preds == y).sum().item()
+            total += y.size(0)
+    avg_loss = total_loss / total
+    accuracy = correct / total
+    return avg_loss, accuracy
+
+
+def train_hybrid_qnn(n_epochs=5, batch_size=16, learning_rate=0.01):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    train_loader, val_loader, test_loader = get_iris_loaders(batch_size=batch_size)
+    num_features = train_loader.dataset[0][0].shape[0]
+    num_classes = 3
+
+    model = HybridQNN(num_features=num_features, num_classes=num_classes, n_vqc_layers=2)
+    model.to(device)
+    optimizer = optim.Adam(model.parameters(), lr=learning_rate)
+    criterion = nn.CrossEntropyLoss()
+
+    history = {'train_loss': [], 'val_loss': [], 'train_acc': [], 'val_acc': []}
+
+    start_time = time.time()
+    for epoch in range(1, n_epochs + 1):
+        model.train()
+        total_loss = 0
+        correct = 0
+        total = 0
+
+        for X, y in train_loader:
+            X, y = X.to(device), y.to(device)
+            optimizer.zero_grad()
+            outputs = model(X)
+            loss = criterion(outputs, y)
+            loss.backward()
+            optimizer.step()
+
+            total_loss += loss.item() * y.size(0)
+            preds = outputs.argmax(dim=1)
+            correct += (preds == y).sum().item()
+            total += y.size(0)
+
+        train_loss = total_loss / total
+        train_acc = correct / total
+        val_loss, val_acc = evaluate_model(model, val_loader, device)
+
+        history['train_loss'].append(train_loss)
+        history['val_loss'].append(val_loss)
+        history['train_acc'].append(train_acc)
+        history['val_acc'].append(val_acc)
+
+        print(f"Epoch {epoch:02d}/{n_epochs} | Train Loss: {train_loss:.4f} | Train Acc: {train_acc:.4f} | Val Loss: {val_loss:.4f} | Val Acc: {val_acc:.4f}")
+
+    end_time = time.time()
+    print(f"\nTraining finished in {end_time - start_time:.2f} seconds.")
+
+    test_loss, test_acc = evaluate_model(model, test_loader, device)
+    print(f"\nFinal Test Loss: {test_loss:.4f} | Test Accuracy: {test_acc:.4f}")
+
+    return model, history, n_epochs
+
+
+def plot_history(history, n_epochs):
+    epochs = range(1, n_epochs + 1)
+    plt.figure(figsize=(12,5))
+    plt.subplot(1,2,2)
+    plt.plot(epochs, history['train_acc'], 'b-', label='Train Acc')
+    plt.plot(epochs, history['val_acc'], 'r-', label='Val Acc')
+    plt.xlabel('Epoch')
+    plt.ylabel('Accuracy')
+    plt.title('Accuracy vs Epoch')
+    plt.grid(True)
+    plt.legend()
+
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    model, history, n_epochs = train_hybrid_qnn(n_epochs=5, batch_size=16, learning_rate=0.01)
+    plot_history(history, n_epochs)

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,16 +1,16 @@
 import pennylane as qml
 import numpy as np
 
-class InputEncoder:
-    def __init__(self,classic_input:np.ndarray,device_type:str='default.qubit'):
 
+class InputEncoder:
+    def __init__(self, classic_input: np.ndarray, device_type: str = 'default.qubit'):
         """
         Initialize encoder with classical input.
         Args:
             classic_input: Input array
-            device_type: Pennylane device type
+            device_type: PennyLane device type
         """
-        self.classic_input = np.asarray(classic_input,dtype=np.float64)
+        self.classic_input = np.asarray(classic_input, dtype=np.float64)
         self.n_qubits = len(self.classic_input)
         self.device_type = device_type
         self.device = None
@@ -21,70 +21,137 @@ class InputEncoder:
         Pad input to the next power of 2 and update n_qubits if needed
         """
         length = len(self.classic_input)
-        next_power_of_2 = 2 ** np.ceil(np.log2(max(length,1))).astype(int)
-        if next_power_of_2> self.n_qubits:
-            self.n_qubits=next_power_of_2
+        next_power_of_2 = 2 ** np.ceil(np.log2(max(length, 1))).astype(int)
+        if next_power_of_2 > self.n_qubits:
+            self.n_qubits = next_power_of_2
 
-        self.classic_input=np.pad(self.classic_input , (0,self.n_qubits-length ),'constant')
+        self.classic_input = np.pad(
+            self.classic_input,
+            (0, self.n_qubits - length),
+            'constant'
+        )
 
-    def prepare_state(self):
+    def prepare_state(self, embedding_type: str):
         """
-        Apply hadamrad gates to all qubits for superpositon
+        Apply Hadamard gates to all qubits for superposition
+        Only used for angle embedding.
         """
-        for i in range(self.n_qubits):
-            qml.Hadamard(wires=i)
+        if embedding_type == "angle":
+            for i in range(self.n_qubits):
+                qml.Hadamard(wires=i)
 
-    def encode_input(self, gate_type:str = 'Y', embedding_type:str = 'angle', operation_type:str = 'initialization', with_padding:bool = False , device:qml.device = None):
+    def encode_input(
+        self,
+        gate_type: str = 'Y',
+        embedding_type: str = 'angle',
+        operation_type: str = 'initialization',
+        with_padding: bool = False,
+        device: qml.device = None,
+        interface: str = 'autograd',
+        operations_list=None,
+        return_state: bool = True
+    ):
         """
-        Encode input into quantum state
+        Encode input into quantum state and optionally apply operations.
 
         Args:
-            gate_type: Rotation gate for angle embedding 
-            embedding_type: angle or amplitude
-            operation_type: initialization (hadamard + embedding)
-            with_padding:pad to power of 2
+            gate_type: Rotation gate for angle embedding ('X','Y','Z')
+            embedding_type: 'angle' or 'amplitude'
+            operation_type: 'initialization' or 'operations'
+            with_padding: pad to power of 2
             device: optional pre-existing device to reuse
+            interface: ML interface for QNode ('autograd','torch','jax','tf')
+            operations_list: list of quantum ops to apply after embedding
+            return_state: if True returns statevector, else expval <Z0>
 
-        Returns: 
-            qml.QNode: qunatum circuit for encoding
+        Returns:
+            qml.QNode: quantum circuit for encoding
         """
-        if with_padding or embedding_type == 'amplitude':
+        # Validate rotation gate
+        valid_rotations = ['X', 'Y', 'Z']
+        if embedding_type == "angle" and gate_type not in valid_rotations:
+            raise ValueError(f"gate_type must be one of {valid_rotations}")
+
+        # Handle padding
+        if embedding_type == "amplitude" or with_padding:
             self.add_padding()
-
         else:
-            self.n_qubits=len(self.classic_input)
+            self.n_qubits = len(self.classic_input)
 
-        self.device=device if device is not None else qml.device(self.device_type, wires = self.n_qubits)
+        # Device initialization
+        self.device = device if device is not None else qml.device(
+            self.device_type, wires=self.n_qubits
+        )
 
-        @qml.qnode(self.device, interface = 'torch', diff_method = 'parameter-shift')
+        @qml.qnode(self.device, interface=interface, diff_method='parameter-shift')
         def circuit():
+            # Initialization embedding
             if operation_type == "initialization":
                 if embedding_type == "angle":
-                    self.prepare_state()
-                    qml.AngleEmbedding(self.classic_input, wires=range(self.n_qubits), rotation=gate_type)
-
+                    self.prepare_state(embedding_type)
+                    qml.AngleEmbedding(
+                        self.classic_input,
+                        wires=range(self.n_qubits),
+                        rotation=gate_type
+                    )
                 elif embedding_type == "amplitude":
-                    qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+                    qml.AmplitudeEmbedding(
+                        self.classic_input,
+                        wires=range(self.n_qubits),
+                        normalize=True,
+                        pad_with=0.0
+                    )
 
+            # Apply additional operations on top of embedding
+            if operations_list:
+                for op in operations_list:
+                    qml.apply(op)
+
+            # Measurement
+            if return_state:
+                return qml.state()
             else:
-                qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+                return qml.expval(qml.PauliZ(0))
 
-            return  qml.state()
         return circuit
-    
+
+
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
-    # Test input
+
+    # Input and device
     input_data = np.asarray([0, 0, 1])
     encoder = InputEncoder(input_data)
-    circuit = encoder.encode_input(with_padding=False)
-    state = circuit()
-    print("Input:", input_data)
-    print("n_qubits:", encoder.n_qubits)
-    print("State:", state)
-    fig, ax = qml.draw_mpl(circuit)()
+    dev = qml.device("default.qubit", wires=3)
+
+    # Case 1: Initialization (angle embedding)
+    # circuit1 = encoder.encode_input(
+    #     device=dev,
+    #     embedding_type="angle",
+    #     gate_type="Y",
+    #     with_padding=False,
+    #     return_state=True
+    # )
+    # state = circuit1()
+    # print("Initialization State:", state)
+
+    # Case 2: Initialization + operations
+    ops = [
+        qml.Hadamard(wires=0),
+        qml.CNOT(wires=[0, 1]),
+        qml.CNOT(wires=[1, 2])
+    ]
+    circuit2 = encoder.encode_input(
+        device=dev,
+        embedding_type="angle",
+        gate_type="Y",
+        with_padding=False,
+        operations_list=ops,
+        return_state=False
+    )
+    result = circuit2()
+    print("Expectation value <Z0>:", result)
+
+    # Draw circuit
+    fig, ax = qml.draw_mpl(circuit2)()
     plt.show()
-
-
-        
-

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -16,25 +16,20 @@ class InputEncoder:
     - QNode is defined once and accepts data as an argument for efficient batching.
     """
     def __init__(self, device_type: str = "default.qubit"):
-        
+
         self.device_type = device_type
         self.random_generator = np.random.default_rng()
 
 
-    def add_padding(self):
-        """
-        Pad input to the next power of 2 and update n_qubits if needed
-        """
-        length = len(self.classic_input)
-        next_power_of_2 = 2 ** np.ceil(np.log2(max(length, 1))).astype(int)
-        if next_power_of_2 > self.n_qubits:
-            self.n_qubits = next_power_of_2
-
-        self.classic_input = np.pad(
-            self.classic_input,
-            (0, self.n_qubits - length),
-            'constant'
-        )
+    @staticmethod
+    def add_padding(vector: np.ndarray) -> Tuple[np.ndarray, int]:
+        """Pads a vector to the next power of 2 for amplitude embedding."""
+        vector = np.asarray(vector, dtype=np.float64).flatten()
+        length = len(vector)
+  
+        next_pow2 = 2 ** int(np.ceil(np.log2(max(length, 1))))
+        padded_vector = np.pad(vector, (0, next_pow2 - length), 'constant')
+        return padded_vector, next_pow2
 
     def prepare_state(self, embedding_type: str):
         """

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,61 +1,90 @@
 import pennylane as qml
 import numpy as np
 
-np.random.seed(11111)
 class InputEncoder:
-    def __init__(self, classic_input: np.ndarray , n_qubits: int, device_type = 'default.qubit'):
-        self.classic_input = classic_input
-        self.n_qubits = n_qubits
-        self.device = qml.device(device_type, wires=n_qubits)
+    def __init__(self,classic_input:np.ndarray,device_type:str='default.qubit'):
+
+        """
+        Initialize encoder with classical input.
+        Args:
+            classic_input: Input array
+            device_type: Pennylane device type
+        """
+        self.classic_input = np.asarray(classic_input,dtype=np.float64)
+        self.n_qubits = len(self.classic_input)
+        self.device_type = device_type
+        self.device = None
         self.random_generator = np.random.default_rng()
+
     def add_padding(self):
-        """"
-        Add padding to the input data to match the number of qubits. 
-        This is done by adding zeros to the end of the input data to make the length
-        the power of 2.
+        """
+        Pad input to the next power of 2 and update n_qubits if needed
         """
         length = len(self.classic_input)
-        next_power_of_2 = 2 ** np.ceil(np.log2(length)).astype(int)
-        padding_length = next_power_of_2 - length
-        self.classic_input = np.pad(self.classic_input, (0, padding_length), 'constant')
+        next_power_of_2 = 2 ** np.ceil(np.log2(max(length,1))).astype(int)
+        if next_power_of_2> self.n_qubits:
+            self.n_qubits=next_power_of_2
 
+        self.classic_input=np.pad(self.classic_input , (0,self.n_qubits-length ),'constant')
 
     def prepare_state(self):
         """
-        Used to prepare the quantum state from classical input data.
-        1. Add padding to the input data to match the number of qubits.
-        2. Apply Hadamard gate to each qubit to create superposition state.
-        3. Return the prepared quantum state.
+        Apply hadamrad gates to all qubits for superpositon
         """
-        # Apply Hadamard gate to each qubit to create superposition state
-        for i in range(len(self.classic_input)):
+        for i in range(self.n_qubits):
             qml.Hadamard(wires=i)
 
+    def encode_input(self, gate_type:str = 'Y', embedding_type:str = 'angle', operation_type:str = 'initialization', with_padding:bool = False , device:qml.device = None):
+        """
+        Encode input into quantum state
 
-    def encode_input(self, device, gate_type='Y', embedding_type = 'angle', operation_type = "initialization", with_padding=True):
-        @qml.qnode(device)
+        Args:
+            gate_type: Rotation gate for angle embedding 
+            embedding_type: angle or amplitude
+            operation_type: initialization (hadamard + embedding)
+            with_padding:pad to power of 2
+            device: optional pre-existing device to reuse
+
+        Returns: 
+            qml.QNode: qunatum circuit for encoding
+        """
+        if with_padding or embedding_type == 'amplitude':
+            self.add_padding()
+
+        else:
+            self.n_qubits=len(self.classic_input)
+
+        self.device=device if device is not None else qml.device(self.device_type, wires = self.n_qubits)
+
+        @qml.qnode(self.device, interface = 'torch', diff_method = 'parameter-shift')
         def circuit():
-            if operation_type == "initialization":  
-                if with_padding:
-                    self.add_padding()
-                if embedding_type == 'angle':
+            if operation_type == "initialization":
+                if embedding_type == "angle":
                     self.prepare_state()
-                    #creating an angle embedding for the input data
-                    qml.AngleEmbedding(self.classic_input, wires=range(len(self.classic_input)), rotation=gate_type)
-                elif embedding_type == 'amplitude':
-                    #creating an amplitude embedding for the input data
-                    qml.AmplitudeEmbedding(self.classic_input, wires=range(len(self.classic_input)), normalize=True, pad_with=0.0)
+                    qml.AngleEmbedding(self.classic_input, wires=range(self.n_qubits), rotation=gate_type)
+
+                elif embedding_type == "amplitude":
+                    qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+
             else:
-                qml.AmplitudeEmbedding(self.classic_input, wires=range(len(self.classic_input)), normalize=True, pad_with=0.0)
-            return qml.expval(qml.PauliZ(0))
+                qml.AmplitudeEmbedding(self.classic_input, wires=range(self.n_qubits), normalize=True, pad_with=0.0)
+
+            return  qml.state()
         return circuit
     
-    
-# if __name__=="__main__":
-#     inst = InputEncoder(np.asarray([0, 0, 1]), 3)
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    # Test input
+    input_data = np.asarray([0, 0, 1])
+    encoder = InputEncoder(input_data)
+    circuit = encoder.encode_input(with_padding=False)
+    state = circuit()
+    print("Input:", input_data)
+    print("n_qubits:", encoder.n_qubits)
+    print("State:", state)
+    fig, ax = qml.draw_mpl(circuit)()
+    plt.show()
 
-#     dev = qml.device('default.qubit', wires=3)
-#     circuit = inst.encode_input(dev)
-#     drawer = qml.draw_mpl(circuit)()
 
-  
+        
+

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -79,17 +79,20 @@ class InputEncoder:
                 raise ValueError(f"Unknown embedding_type: {embedding_type}")
         
         return func
-    def operations_function(self, operation_list=None):
-        """
-        Returns a function that applies only the given operations.
-        Can be inserted into another QNode
-        """
+    
+    
+    @staticmethod
+    def operations_function(operation_list: Optional[List[Union[qml.operation.Operation, Callable]]] = None) -> Callable[[], None]:
+        """Returns a function that applies a list of pre-defined operations."""
         def func():
             if operation_list:
                 for op in operation_list:
-                    qml.apply(op)
-
+                    if callable(op):
+                        op()
+                    else:
+                        qml.apply(op)
         return func
+
     def build_full_circuit(
             self,
             embedding_type:str = "angle",

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,21 +1,25 @@
 import pennylane as qml
 import numpy as np
 import matplotlib.pyplot as plt
+from typing import Callable, List, Optional, Union, Tuple
 
-
+ArrayLike = Union[np.ndarray, List[float]]
 class InputEncoder:
-    def __init__(self, classic_input: np.ndarray, device_type: str = 'default.qubit'):
-        """
-        Initialize encoder with classical input.
-        Args:
-            classic_input: Input array
-            device_type: PennyLane device type
-        """
-        self.classic_input = np.asarray(classic_input, dtype=np.float64)
-        self.n_qubits = len(self.classic_input)
+    """
+    Stateless, modular quantum input encoder for feedforward VQC networks.
+
+    Supports:
+    - AngleEmbedding (rotation gates)
+    - AmplitudeEmbedding (normalized, padded)
+    
+    IMPORTANT:
+    - QNode is defined once and accepts data as an argument for efficient batching.
+    """
+    def __init__(self, device_type: str = "default.qubit"):
+        
         self.device_type = device_type
-        self.device = None
         self.random_generator = np.random.default_rng()
+
 
     def add_padding(self):
         """

--- a/src/vqc_fnn/models/input_encoder.py
+++ b/src/vqc_fnn/models/input_encoder.py
@@ -1,5 +1,6 @@
 import pennylane as qml
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 class InputEncoder:
@@ -117,7 +118,7 @@ class InputEncoder:
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
+   
 
     # Input and device
     input_data = np.asarray([0, 0, 1])
@@ -125,33 +126,33 @@ if __name__ == "__main__":
     dev = qml.device("default.qubit", wires=3)
 
     # Case 1: Initialization (angle embedding)
-    # circuit1 = encoder.encode_input(
-    #     device=dev,
-    #     embedding_type="angle",
-    #     gate_type="Y",
-    #     with_padding=False,
-    #     return_state=True
-    # )
-    # state = circuit1()
-    # print("Initialization State:", state)
-
-    # Case 2: Initialization + operations
-    ops = [
-        qml.Hadamard(wires=0),
-        qml.CNOT(wires=[0, 1]),
-        qml.CNOT(wires=[1, 2])
-    ]
-    circuit2 = encoder.encode_input(
+    circuit1 = encoder.encode_input(
         device=dev,
         embedding_type="angle",
         gate_type="Y",
         with_padding=False,
-        operations_list=ops,
-        return_state=False
+        return_state=True
     )
-    result = circuit2()
-    print("Expectation value <Z0>:", result)
+    state = circuit1()
+    print("Initialization State:", state)
+
+    # Case 2: Initialization + operations
+    # ops = [
+    #     qml.Hadamard(wires=0),
+    #     qml.CNOT(wires=[0, 1]),
+    #     qml.CNOT(wires=[1, 2])
+    # ]
+    # circuit2 = encoder.encode_input(
+    #     device=dev,
+    #     embedding_type="angle",
+    #     gate_type="Y",
+    #     with_padding=False,
+    #     operations_list=ops,
+    #     return_state=False
+    # )
+    # result = circuit2()
+    # print("Expectation value <Z0>:", result)
 
     # Draw circuit
-    fig, ax = qml.draw_mpl(circuit2)()
+    # fig, ax = qml.draw_mpl(circuit2)()
     plt.show()

--- a/src/vqc_fnn/models/vqc_layer.py
+++ b/src/vqc_fnn/models/vqc_layer.py
@@ -1,12 +1,98 @@
 from torch import nn
+import torch
 import pennylane as qml
-from qiskit import QuantumCircuit
 from input_encoder import InputEncoder
+from qiskit import QuantumCircuit
+import numpy as np
+
 class VQCLayer(nn.Module):
-    def __init__(self, num_qubits, q_circuit: QuantumCircuit | qml.QuantumCircuit):
+    def __init__(self, num_qubits, q_circuit: QuantumCircuit | None = None, n_layers: int = 1, encoder: InputEncoder | None = None):
+        """
+        Variational Quantum Circuit (VQC) Layer.
+
+        Args:
+            num_qubits (int): Number of qubits in the VQC.
+            q_circuit (QuantumCircuit | None): Optional custom Qiskit or Pennylane circuit.
+            n_layers (int): Number of entangler layers if using default Pennylane VQC.
+            encoder (InputEncoder | None): Optional InputEncoder for classical-to-quantum encoding.
+        """
         super(VQCLayer, self).__init__()
-        
+        self.num_qubits = num_qubits
+        self.encoder = encoder
+        self.n_layers = n_layers
+
+        # Initialize Pennylane device
+        self.dev = qml.device("default.qubit", wires=self.num_qubits)
+
+        # Trainable parameters for the entangler layers
+        self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=self.n_layers, n_wires=self.num_qubits)
+        self.weights = nn.Parameter(torch.randn(*self.weight_shape) * np.pi)
+
+        # Define QNode using the provided circuit or default
+        self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
+
+    def _circuit(self, weights, inputs=None):
+        """
+        Quantum circuit for the VQC layer.
+
+        Args:
+            weights: Trainable parameters for entangler layers.
+            inputs: Classical input tensor for encoding.
+        """
+        # Encode classical input if encoder provided
+        if self.encoder is not None and inputs is not None:
+            # Convert torch.Tensor to numpy
+            self.encoder.classic_input = inputs.detach().cpu().numpy()
+            # Generate the circuit
+            self.encoder.encode_input(
+                gate_type='Y',
+                embedding_type='angle',
+                operation_type='initialization',
+                with_padding=False,
+                device=self.dev,
+                interface="torch",
+                operations_list=None,
+                return_state=False
+            )()
+
+        # Apply variational entangler layers
+        qml.BasicEntanglerLayers(weights, wires=range(self.num_qubits))
+
+        # Measure all qubits
+        return [qml.expval(qml.PauliZ(i)) for i in range(self.num_qubits)]
+
     def forward(self, input_):
-       pass
+        """
+        Forward pass through the VQC layer.
+
+        Args:
+            input_ (torch.Tensor): Input tensor of shape (batch_size, num_qubits) or (num_qubits,)
+
+        Returns:
+            torch.Tensor: Output tensor of shape (batch_size, num_qubits)
+        """
+        if isinstance(input_, torch.Tensor):
+            input_ = input_.float()
+
+        # Single input
+        if len(input_.shape) == 1:
+            return self.qnode(self.weights, inputs=input_)
+        # Batch input
+        else:
+            batch_out = [self.qnode(self.weights, inputs=x_i) for x_i in input_]
+            return torch.stack(batch_out)
+
     def backward(self, grad_output):
-       pass
+        """
+        Optional: define backward pass if using custom gradients.
+        For standard PyTorch + Pennylane, autograd handles gradients automatically.
+        """
+        pass
+
+if __name__ == '__main__':
+    x = torch.tensor([0.1, 0.5, 0.9])
+    encoder = InputEncoder(classic_input=x.numpy())
+    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
+
+    output = vqc(x)
+    print("VQC output:", output)

--- a/src/vqc_fnn/models/vqc_layer.py
+++ b/src/vqc_fnn/models/vqc_layer.py
@@ -1,87 +1,80 @@
-from torch import nn
 import torch
+from torch import nn
 import pennylane as qml
+import numpy as np
 from input_encoder import InputEncoder
 from qiskit import QuantumCircuit
-import numpy as np
 
 class VQCLayer(nn.Module):
-    def __init__(self, num_qubits, q_circuit: QuantumCircuit | None = None, n_layers: int = 1, encoder: InputEncoder | None = None):
+    def __init__(
+        self, 
+        num_qubits: int,
+        encoder: InputEncoder | None = None,
+        ansatz_fn=None,
+        n_layers: int = 1, 
+        device_type: str = "default.qubit",
+        measurement_fn=None,
+        q_circuit: QuantumCircuit | None = None, 
+    ):
         """
         Variational Quantum Circuit (VQC) Layer.
-
-        Args:
-            num_qubits (int): Number of qubits in the VQC.
-            q_circuit (QuantumCircuit | None): Optional custom Qiskit or Pennylane circuit.
-            n_layers (int): Number of entangler layers if using default Pennylane VQC.
-            encoder (InputEncoder | None): Optional InputEncoder for classical-to-quantum encoding.
         """
-        super(VQCLayer, self).__init__()
+        super().__init__()
         self.num_qubits = num_qubits
         self.encoder = encoder
         self.n_layers = n_layers
+        self.q_circuit = q_circuit
 
         # Initialize Pennylane device
-        self.dev = qml.device("default.qubit", wires=self.num_qubits)
+        self.dev = qml.device(device_type, wires=self.num_qubits)
 
-        # Trainable parameters for the entangler layers
-        self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=self.n_layers, n_wires=self.num_qubits)
+        # Default ansatz if not provided
+        if ansatz_fn is None:
+            self.ansatz_fn = lambda weights: qml.BasicEntanglerLayers(weights, wires=range(num_qubits))
+            self.weight_shape = qml.BasicEntanglerLayers.shape(n_layers=n_layers, n_wires=num_qubits)
+        else:
+            self.ansatz_fn = ansatz_fn
+            self.weight_shape = getattr(ansatz_fn, "weight_shape", (n_layers, num_qubits))
+
+        # Trainable weights
         self.weights = nn.Parameter(torch.randn(*self.weight_shape) * np.pi)
 
-        # Define QNode using the provided circuit or default
-        self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
+        # Default measurement: Z expectation on all qubits
+        if measurement_fn is None:
+            self.measurement_fn = lambda: [qml.expval(qml.PauliZ(i)) for i in range(num_qubits)]
+        else:
+            self.measurement_fn = measurement_fn
+
+        # Define QNode (custom circuit if provided)
+        if self.q_circuit is not None:
+            self.qnode = qml.QNode(self.q_circuit, self.dev, interface="torch")
+        else:
+            self.qnode = qml.QNode(self._circuit, self.dev, interface="torch", diff_method="parameter-shift")
 
     def _circuit(self, weights, inputs=None):
-        """
-        Quantum circuit for the VQC layer.
-
-        Args:
-            weights: Trainable parameters for entangler layers.
-            inputs: Classical input tensor for encoding.
-        """
+        """Quantum circuit for the VQC layer."""
         # Encode classical input if encoder provided
         if self.encoder is not None and inputs is not None:
-            # Convert torch.Tensor to numpy
             self.encoder.classic_input = inputs.detach().cpu().numpy()
-            # Generate the circuit
-            self.encoder.encode_input(
-                gate_type='Y',
-                embedding_type='angle',
-                operation_type='initialization',
-                with_padding=False,
-                device=self.dev,
-                interface="torch",
-                operations_list=None,
-                return_state=False
-            )()
+            embedding_fn = self.encoder.embedding_function(embedding_type="angle", gate_type="Y")
+            embedding_fn()
 
-        # Apply variational entangler layers
-        qml.BasicEntanglerLayers(weights, wires=range(self.num_qubits))
+        # Variational ansatz
+        self.ansatz_fn(weights)
 
-        # Measure all qubits
-        return [qml.expval(qml.PauliZ(i)) for i in range(self.num_qubits)]
+        # Measurement
+        return self.measurement_fn()
 
     def forward(self, input_):
-        """
-        Forward pass through the VQC layer.
+        """Forward pass with batch support."""
+        input_ = input_.float() if isinstance(input_, torch.Tensor) else input_
 
-        Args:
-            input_ (torch.Tensor): Input tensor of shape (batch_size, num_qubits) or (num_qubits,)
-
-        Returns:
-            torch.Tensor: Output tensor of shape (batch_size, num_qubits)
-        """
-        if isinstance(input_, torch.Tensor):
-            input_ = input_.float()
-
-        # Single input
-        if len(input_.shape) == 1:
+        if len(input_.shape) == 1:  # single input
             return self.qnode(self.weights, inputs=input_)
-        # Batch input
-        else:
+        else:  # batch
             batch_out = [self.qnode(self.weights, inputs=x_i) for x_i in input_]
             return torch.stack(batch_out)
-
+        
     def backward(self, grad_output):
         """
         Optional: define backward pass if using custom gradients.
@@ -89,10 +82,22 @@ class VQCLayer(nn.Module):
         """
         pass
 
+
 if __name__ == '__main__':
     x = torch.tensor([0.1, 0.5, 0.9])
     encoder = InputEncoder(classic_input=x.numpy())
-    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
 
-    output = vqc(x)
-    print("VQC output:", output)
+    # Default VQC
+    vqc = VQCLayer(num_qubits=3, n_layers=2, encoder=encoder)
+    print("Default VQC output:", vqc(x))
+
+    # Custom ansatz
+    ansatz = lambda weights: qml.StronglyEntanglingLayers(weights, wires=range(3))
+    ansatz.weight_shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3)
+    vqc_custom = VQCLayer(num_qubits=3, encoder=encoder, ansatz_fn=ansatz)
+    print("Custom ansatz output:", vqc_custom(x))
+
+    # Custom measurement
+    measure_qubit0 = lambda: qml.expval(qml.PauliZ(0))
+    vqc_measure = VQCLayer(num_qubits=3, encoder=encoder, measurement_fn=measure_qubit0)
+    print("Custom measurement output:", vqc_measure(x))

--- a/src/vqc_fnn/models/vqc_layer.py
+++ b/src/vqc_fnn/models/vqc_layer.py
@@ -42,6 +42,18 @@ class VQCLayer(nn.Module):
         self.qnode_cache: Dict[Tuple[int, str, str], Dict[str, Any]] = {}
         self.weights_dict: Dict[int, nn.Parameter] = {}
 
+    def _default_weight_shape(self, n_qubits: int) -> Tuple[int, ...]:
+        """Provides default shape for BasicEntanglerLayers."""
+        return qml.BasicEntanglerLayers.shape(n_layers=self.n_layers, n_wires=n_qubits)
+
+    @staticmethod
+    def _next_power_of_two_int(n: int) -> int:
+        """Utility: compute next power of two (pure python)."""
+        if n <= 0: return 1
+        if (n & (n - 1)) == 0: return n
+        return 1 << (n.bit_length())
+
+
 
     def _circuit(self, weights, inputs=None):
         """Quantum circuit for the VQC layer."""


### PR DESCRIPTION
1. input_encoder.py

- Converted the encoder to a stateless architecture

(no stored classical inputs or device references).

- Encoder now accepts inputs directly in each forward pass.

- Added batch support

2. VQCLayer Improvements

- Updated interfaces to work cleanly with the stateless encoder.

- Added caching

3. Hybrid Model Test Added

- Added a new file using the Iris dataset

